### PR TITLE
Fix installer leaks and reCAPTCHA configuration

### DIFF
--- a/private/functions.php
+++ b/private/functions.php
@@ -1904,28 +1904,33 @@ function initializeConfigFile($providedConfig) {
 
     // File does ! not exist so create it and initialize it with the configuration provided.
     //echo 'file did not exist';
-    $library_name = "define('institutionName', '" . $providedConfig['library_name'] . "');";
-    $appserver_name = "define('appServer', '" . $providedConfig['appserver_name'] . "');";
-    $api_key = "define('apiKey', '" . $providedConfig['api_key'] . "');";
-    $api_secret = "define('apiSecret', '" . $providedConfig['api_secret'] . "');";
-    $api_ver = "define('apiVer', '" . $providedConfig['api_ver'] . "');";
-    $country = "define('localization', '" . $providedConfig['country'] . "');";
-    $pinlength = "define('minimumPinLength', '" . $providedConfig['pinlength'] . "');";
-    $startbarcode = "define('startingBarcodeNumber', '" . $providedConfig['startbarcode'] . "');";
-    $barcodeprefix = "define('barcodePrefix', '" . $providedConfig['barcodeprefix'] . "');";
-    $use_recaptcha = "define('useRecaptcha', '" . $providedConfig['use_recaptcha'] . "');";
-    $recaptcha_site = "define('recaptchaSiteKey', '" . $providedConfig['recaptcha_site'] . "');";
-    $recaptcha_secret = "define('recaptchaSecretKey', '" . $providedConfig['recaptcha_secret'] . "');";
-    $google_analytics = "define('useGoogleAnalytics', '" . $providedConfig['google_analytics'] . "');";
-    $ga_property = "define('googleAnalyticsID', '" . $providedConfig['ga_property'] . "');";
-    $address_verification = "define('verifyAddress', '" . $providedConfig['address_verification'] . "');";
-    $bing_key = "define('bingMapsKey', '" . $providedConfig['bing_key'] . "');";
-    $verify_catchment = "define('verifyCatchment', '" . $providedConfig['verify_catchment'] . "');";
-    $catchment_fail = "define('catchmentFailedRedirectPage', '" . $providedConfig['catchment_fail'] . "');";
-    $your_province = "define('yourprovince', '" . $providedConfig['yourprovince'] . "');";
-    $patronTypeNumber = "define('patronTypeNumber', '" . $providedConfig['patrontypenumber'] . "');";
-    $patronStatsSecret = "define('patronStatsSecret', '" . $providedConfig['patronStatsSecret'] . "');";
-    $mailFrom = "define('mailFrom', '" . $providedConfig['mailFrom'] . "');";
+    $buildDefine = function($name, $value) {
+      $sanitizedValue = ($value === null) ? '' : $value;
+      return "define('{$name}', " . var_export($sanitizedValue, true) . ");";
+    };
+
+    $library_name = $buildDefine('institutionName', $providedConfig['library_name']);
+    $appserver_name = $buildDefine('appServer', $providedConfig['appserver_name']);
+    $api_key = $buildDefine('apiKey', $providedConfig['api_key']);
+    $api_secret = $buildDefine('apiSecret', $providedConfig['api_secret']);
+    $api_ver = $buildDefine('apiVer', $providedConfig['api_ver']);
+    $country = $buildDefine('localization', $providedConfig['country']);
+    $pinlength = $buildDefine('minimumPinLength', $providedConfig['pinlength']);
+    $startbarcode = $buildDefine('startingBarcodeNumber', $providedConfig['startbarcode']);
+    $barcodeprefix = $buildDefine('barcodePrefix', $providedConfig['barcodeprefix']);
+    $use_recaptcha = $buildDefine('useRecaptcha', $providedConfig['use_recaptcha']);
+    $recaptcha_site = $buildDefine('recaptchaSiteKey', $providedConfig['recaptcha_site']);
+    $recaptcha_secret = $buildDefine('recaptchaSecretKey', $providedConfig['recaptcha_secret']);
+    $google_analytics = $buildDefine('useGoogleAnalytics', $providedConfig['google_analytics']);
+    $ga_property = $buildDefine('googleAnalyticsID', $providedConfig['ga_property']);
+    $address_verification = $buildDefine('verifyAddress', $providedConfig['address_verification']);
+    $bing_key = $buildDefine('bingMapsKey', $providedConfig['bing_key']);
+    $verify_catchment = $buildDefine('verifyCatchment', $providedConfig['verify_catchment']);
+    $catchment_fail = $buildDefine('catchmentFailedRedirectPage', $providedConfig['catchment_fail']);
+    $your_province = $buildDefine('yourprovince', $providedConfig['yourprovince']);
+    $patronTypeNumber = $buildDefine('patronTypeNumber', $providedConfig['patrontypenumber']);
+    $patronStatsSecret = $buildDefine('patronStatsSecret', $providedConfig['patronStatsSecret']);
+    $mailFrom = $buildDefine('mailFrom', $providedConfig['mailFrom']);
 
     $writefile = fopen('../../private/config.php', "w");
     if(!$writefile) { echo 'could not open file for writing'; }

--- a/public/html/form.php
+++ b/public/html/form.php
@@ -49,7 +49,7 @@ if(useRecaptcha == '1') {
     <![endif]-->
 
     <!-- I am pulling in my site key from the config file -->
-    <script src="https://www.google.com/recaptcha/api.js?render=<?php echo captcha_site_key; ?>"></script>
+    <script src="https://www.google.com/recaptcha/api.js?render=<?php echo defined('recaptchaSiteKey') ? recaptchaSiteKey : ''; ?>"></script>
 
 
 
@@ -271,7 +271,7 @@ if(useRecaptcha == '1') {
 
 <script>
     grecaptcha.ready(function() {
-        grecaptcha.execute('<?php echo captcha_site_key; ?>', {action: 'homepage'}).then(function(token) {
+        grecaptcha.execute('<?php echo defined('recaptchaSiteKey') ? recaptchaSiteKey : ''; ?>', {action: 'homepage'}).then(function(token) {
         ...
         });
     });

--- a/public/html/install.php
+++ b/public/html/install.php
@@ -24,7 +24,6 @@ if(!extension_loaded('curl')) {
 
 
 if(is_post_request()) {
-    pre($_POST);
     $barcodeprefix = substr($_POST['startbarcode'], 0, $_POST['barcodeprefix']);
     $providedConfig['library_name'] = $_POST['library_name'];
     $providedConfig['appserver_name'] = $_POST['appserver_name'];
@@ -50,7 +49,6 @@ if(is_post_request()) {
     $providedConfig['mailFrom'] = $_POST['mailFrom'];
 
     initializeConfigFile($providedConfig);
-    echo 'initialized the configuration';
     initializeBarcodeFile($_POST['startbarcode']);
 
     header('Location: index.php');
@@ -86,7 +84,7 @@ if(is_post_request()) {
     <![endif]-->
 
     <!-- I am pulling in my site key from the config file -->
-    <script src="https://www.google.com/recaptcha/api.js?render=<?php echo captcha_site_key; ?>"></script>
+    <script src="https://www.google.com/recaptcha/api.js?render=<?php echo defined('recaptchaSiteKey') ? recaptchaSiteKey : ''; ?>"></script>
 
         <script type="text/javascript">
             function populate(s1,s2){
@@ -363,7 +361,7 @@ if(is_post_request()) {
 
 <script>
     grecaptcha.ready(function() {
-        grecaptcha.execute('<?php echo captcha_site_key; ?>', {action: 'homepage'}).then(function(token) {
+        grecaptcha.execute('<?php echo defined('recaptchaSiteKey') ? recaptchaSiteKey : ''; ?>', {action: 'homepage'}).then(function(token) {
         ...
         });
     });

--- a/public/html/patronpostpatron.php
+++ b/public/html/patronpostpatron.php
@@ -184,7 +184,7 @@ header('Location: \index.php');
     <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
 
-    <script src="https://www.google.com/recaptcha/api.js?render=<?php echo captcha_site_key; ?>"></script>
+    <script src="https://www.google.com/recaptcha/api.js?render=<?php echo defined('recaptchaSiteKey') ? recaptchaSiteKey : ''; ?>"></script>
 </head>
 
 <body background="images/ecardbackground.png">


### PR DESCRIPTION
## Summary
- prevent the installer from echoing submitted secrets before redirecting
- escape generated config values to tolerate quotes in user input
- update reCAPTCHA usage to reference the configured site key on every page

## Testing
- php -l public/html/install.php
- php -l public/html/form.php
- php -l public/html/patronpostpatron.php
- php -l private/functions.php

------
https://chatgpt.com/codex/tasks/task_b_690cf98fe2c88325ab6244609c4562ad